### PR TITLE
Created Vp test for creating a Vp and create action for Vp controller

### DIFF
--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,3 +1,18 @@
-class ViewingPartiesController < ApplicationController
-  
+class Api::V1::ViewingPartiesController < ApplicationController
+  def create
+    viewing_party = ViewingParty.create_with_invitees(party_params, @current_user)
+
+    if viewing_party
+      render json: ViewingPartySerializer.new(viewing_party).serializable_hash, status: :created
+    else
+      render json: { error: viewing_party.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def party_params
+    params.permit(:name, :start_time, :end_time, :movie_id, :movie_title, invitees: [])
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::API
   private
 
   def authorize_api_key
-    current_user = User.find_by(api_key: params[:api_key])
-    render json: { error: 'Invalid API key' }, status: :unauthorized unless current_user
+    @current_user = User.find_by(api_key: params[:api_key])
+    render json: { error: 'Invalid API key' }, status: :unauthorized unless @current_user
   end
 end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -4,4 +4,19 @@ class ViewingParty < ApplicationRecord
   has_many :users, through: :viewing_party_users
 
   validates :name, :start_time, :end_time, :movie_id, :movie_title, presence: true
+
+  def self.create_with_invitees(party_params, host)
+    viewing_party = new(party_params.except(:invitees))
+    viewing_party.host = host
+
+    if viewing_party.save
+      party_params[:invitees].each do |invitee_id|
+        user = User.find_by(id: invitee_id)
+        viewing_party.users << user if user
+      end
+      viewing_party
+    else
+      nil
+    end
+  end
 end

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -1,5 +1,14 @@
-class ViewingPartySerializer < ActiveModel::Serializer
+class ViewingPartySerializer 
+  include JSONAPI::Serializer
   attributes :id, :name, :start_time, :end_time, :movie_id, :movie_title
 
-  
+  attribute :invitees do |viewing_party|
+    viewing_party.users.map do |user|
+      {
+        id: user.id,
+        name: user.name,
+        username: user.username
+      }
+    end
+  end
 end

--- a/spec/requests/api/v1/viewing_party_request.rb
+++ b/spec/requests/api/v1/viewing_party_request.rb
@@ -1,3 +1,39 @@
 require 'rails_helper'
 
-describe 
+RSpec.describe "ViewingParty", type: :request do 
+  describe "Create viewing party" do 
+    it 'creates a viewing party with all the neccessary attributes' do
+      user = User.create!(name: "Danny DeVito", username: "danny_de_v", api_key: "e1An2gAidDbWtJuhbHFKryjU", password: "jerseyMikesRox7")
+      invitee1 = User.create(name: "Hannah", username: "ha_merc", password: "mercado1234")
+      invitee2 = User.create(name: "Sabrina", username: "sa_dela", password: "delarosa123")
+      invitee3 = User.create(name: "Aldo", username: "al_merc", password: "al_mercado1234")
+      party_params = {
+        "name": "Juliet's Bday Movie Bash!",
+        "start_time": "2025-02-01 10:00:00",
+        "end_time": "2025-02-01 14:30:00",
+        "movie_id": 278,
+        "movie_title": "The Shawshank Redemption",
+        "api_key": user.api_key, 
+        "invitees": [invitee1.id, invitee2.id, invitee3.id] 
+      }
+      post "/api/v1/viewing_parties",  params: party_params 
+      
+      expect(response).to be_successful
+
+      new_party = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+      
+      expect(new_party[:end_time]).to be_a(String)
+      expect(new_party[:id]).to be_a(Integer)
+      expect(new_party).to have_key(:invitees)
+      expect(new_party[:invitees]).to be_an(Array)
+
+      new_party[:invitees].each do |invitee|
+        expect(invitee).to have_key(:id)
+        expect(invitee[:id]).to be_an(Integer)
+        expect(invitee).to have_key(:name)
+        expect(invitee[:name]).to be_a(String)
+        expect(invitee).to have_key(:username)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the creation of viewing parties within the Api::V1::ViewingPartiesController. Key features include:

Viewing Party Creation: Added a create action to handle incoming requests and create a new viewing party along with associated invitees.
API Key Authorization: Moved API key authorization logic to the ApplicationController for centralized handling.
Model Logic: Introduced a create_with_invitees method in the ViewingParty model to encapsulate the logic for creating viewing parties and associating invitees, raising errors on failure.
Serializer Updates: Enhanced the ViewingPartySerializer to include invitee details in the response.
RSpec Tests: Developed comprehensive request specs to validate the viewing party creation process and response structure.