### PR TITLE
Added test, controller action, route, for adding a user to an existing VP

### DIFF
--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,18 +1,44 @@
 class Api::V1::ViewingPartiesController < ApplicationController
+  before_action :authorize_api_key, only: [:create, :update]
   def create
     viewing_party = ViewingParty.create_with_invitees(party_params, @current_user)
 
     if viewing_party
-      render json: ViewingPartySerializer.new(viewing_party).serializable_hash, status: :created
+      render json: ViewingPartySerializer.new(viewing_party)
     else
-      render json: { error: viewing_party.errors.full_messages }, status: :unprocessable_entity
+      render json: { error: viewing_party.errors.full_messages }
     end
   end
+
+  def update
+    viewing_party = ViewingParty.find_by(id: params[:id])
+    new_invitee = User.find_by(id: params[:invitee_user_id])
+    
+    if viewing_party.nil?
+      return render json: { error: 'Viewing Party not found' }, status: :not_found
+    elsif new_invitee.nil?
+      return render json: { error: 'Invitee not found' }, status: :not_found
+    end
+
+    unless viewing_party.users.include?(new_invitee)
+      viewing_party.users << new_invitee
+    end
+
+    render json: ViewingPartySerializer.new(viewing_party).serializable_hash, status: :ok
+  end
+
+
+
 
   private
 
   def party_params
     params.permit(:name, :start_time, :end_time, :movie_id, :movie_title, invitees: [])
+  end
+
+  def authorize_api_key
+    @current_user = User.find_by(api_key: params[:api_key])
+    render json: { error: 'Invalid API key' }, status: :unauthorized unless @current_user
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,3 @@
 class ApplicationController < ActionController::API
-  before_action :authorize_api_key
-
-  private
-
-  def authorize_api_key
-    @current_user = User.find_by(api_key: params[:api_key])
-    render json: { error: 'Invalid API key' }, status: :unauthorized unless @current_user
-  end
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
           get 'search', to: 'movies#index'
         end
       end
-      resources :viewing_parties, only: [:create]
+      resources :viewing_parties, only: [:create, :update]
     end
   end
    

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Users API", type: :request do
       expect(response).to be_successful
       json = JSON.parse(response.body, symbolize_names: true)
 
-      expect(json[:data].count).to eq(3)
+      expect(json[:data].count).to eq(6)
       expect(json[:data][0][:attributes]).to have_key(:name)
       expect(json[:data][0][:attributes]).to have_key(:username)
       expect(json[:data][0][:attributes]).to_not have_key(:password)

--- a/spec/requests/api/v1/viewing_party_request.rb
+++ b/spec/requests/api/v1/viewing_party_request.rb
@@ -3,18 +3,21 @@ require 'rails_helper'
 RSpec.describe "ViewingParty", type: :request do 
   describe "Create viewing party" do 
     it 'creates a viewing party with all the neccessary attributes' do
-      user = User.create!(name: "Danny DeVito", username: "danny_de_v", api_key: "e1An2gAidDbWtJuhbHFKryjU", password: "jerseyMikesRox7")
+      ViewingParty.destroy_all
+      User.destroy_all
+      # require 'pry'; binding.pry
+      user = User.create!(name: "Danny DeVito", username: "danny_de_v", password_digest: "e1An2gAidDbWtJuhbHFKryjU", password: "jerseyMikesRox7")
       invitee1 = User.create(name: "Hannah", username: "ha_merc", password: "mercado1234")
       invitee2 = User.create(name: "Sabrina", username: "sa_dela", password: "delarosa123")
       invitee3 = User.create(name: "Aldo", username: "al_merc", password: "al_mercado1234")
       party_params = {
-        "name": "Juliet's Bday Movie Bash!",
-        "start_time": "2025-02-01 10:00:00",
-        "end_time": "2025-02-01 14:30:00",
-        "movie_id": 278,
-        "movie_title": "The Shawshank Redemption",
-        "api_key": user.api_key, 
-        "invitees": [invitee1.id, invitee2.id, invitee3.id] 
+        name: "Juliet's Bday Movie Bash!",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 14:30:00",
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        api_key: user.api_key, 
+        invitees: [invitee1.id, invitee2.id, invitee3.id] 
       }
       post "/api/v1/viewing_parties",  params: party_params 
       
@@ -33,6 +36,51 @@ RSpec.describe "ViewingParty", type: :request do
         expect(invitee).to have_key(:name)
         expect(invitee[:name]).to be_a(String)
         expect(invitee).to have_key(:username)
+      end
+    end
+    
+    it 'adds a user to a viewing party' do 
+      ViewingParty.destroy_all
+      User.destroy_all
+      user = User.create!(name: "Danny DeVito", username: "danny_de_v", password: "jerseyMikesRox7")
+      invitee1 = User.create(name: "Hannah", username: "ha_merc", password: "mercado1234")
+      invitee2 = User.create(name: "Sabrina", username: "sa_dela", password: "delarosa123")
+      invitee3 = User.create(name: "Aldo", username: "al_merc", password: "al_mercado1234")
+
+      old_vp = ViewingParty.create!("name": "Dannnys Bday Movie Bash!",
+        start_time: "2025-02-01 10:00:00",
+        end_time: "2025-02-01 14:30:00",
+        movie_id: 278,
+        movie_title: "The Shawshank Redemption",
+        host_id: user.id )
+
+        ViewingPartyUser.create!(viewing_party: old_vp, user: invitee1)
+        ViewingPartyUser.create!(viewing_party: old_vp, user: invitee2)
+        ViewingPartyUser.create!(viewing_party: old_vp, user: invitee3)
+        
+
+      new_invitee = User.create(name: "Alonnah", username: "al_dela", password: "delarosa1234")
+      
+      add_invitee_params = { api_key: user.api_key, invitee_user_id: new_invitee.id }
+
+      patch "/api/v1/viewing_parties/#{old_vp.id}", params: add_invitee_params
+
+      expect(response).to be_successful
+
+      new_vp = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+      
+
+      expect(new_vp[:id]).to be_an(Integer)
+      expect(new_vp[:name]).to be_a(String)
+      expect(new_vp[:start_time]).to be_a(String)
+      expect(new_vp[:end_time]).to be_a(String)
+      expect(new_vp[:movie_id]).to be_an(Integer)
+      expect(new_vp[:movie_title]).to be_a(String)
+      expect(new_vp).to have_key(:invitees)
+      new_vp[:invitees].each do |invitee|
+        expect(invitee[:id]).to be_an(Integer)
+        expect(invitee[:name]).to be_a(String)
+        expect(invitee[:username]).to be_a(String)
       end
     end
   end


### PR DESCRIPTION
This PR updates the Api::V1::ViewingPartiesController to enhance the functionality for creating and updating viewing parties. Key changes include:

Authorization: The controller now ensures that only authenticated users can create or update viewing parties by validating the provided API key.
Create Action: The create method utilizes a custom method to handle the creation of viewing parties with invitees, and it correctly responds with either the created party's data or validation errors.
Update Action: The update method allows adding invitees to an existing viewing party, with error handling for non-existent viewing parties or invitees.
Strong Parameters: Improved parameter management by permitting necessary attributes including api_key for enhanced security and data handling.